### PR TITLE
Medprompt

### DIFF
--- a/evaluation/inference.py
+++ b/evaluation/inference.py
@@ -176,6 +176,7 @@ def benchmark_infer(args, tokenizer, data, client=None, seed=1234):
             client, tokenizer,
             prompts, stop_seq, max_len,
             cot=args.cot, temperature=temperature)
+
         for prompt, out in zip(batch["prompt"], outputs):
             predictions.loc[predictions['prompt'] == prompt, 'output'] = out
         batch_counter += 1

--- a/gap-replay/guidelines/clean.py
+++ b/gap-replay/guidelines/clean.py
@@ -916,7 +916,6 @@ def combine_guidelines(dir_path, out_path, sources=None, min_chars=10):
     for file in jsonl_files:
         if sources and not any([s in file for s in sources]):
             continue
-        print(file)
         source_guidelines = read_jsonl(os.path.join(dir_path, file))
         source_guidelines = [g for g in source_guidelines if g[k] and len(g[k]) > min_chars]
         guidelines.extend(source_guidelines)

--- a/gap-replay/guidelines/clean.py
+++ b/gap-replay/guidelines/clean.py
@@ -912,14 +912,20 @@ def combine_guidelines(dir_path, out_path, sources=None, min_chars=10):
     Combine all guidelines from a directory into a single file.
     '''
     guidelines = []
-    k = "clean_text"
     jsonl_files = sorted([file for file in os.listdir(dir_path) if (file.endswith('.jsonl') and 'guideline' not in file)])
     for file in jsonl_files:
         if sources and not any([s in file for s in sources]):
             continue
+        print(file)
         source_guidelines = read_jsonl(os.path.join(dir_path, file))
-        source_guidelines = [g for g in source_guidelines if g[k] and len(g[k]) > min_chars]
-        guidelines.extend(source_guidelines)
+        if 'clean_text' in source_guidelines[0].keys():
+            for g in source_guidelines:
+                g_new = g.copy()
+                g_new['text'] = g['clean_text']
+                del g_new['raw_text']
+                del g_new['clean_text']
+                if len(g['text']) > min_chars:
+                    guidelines.append(g_new)
     with open(out_path, 'w') as f_out:
         f_out.write('\n'.join([json.dumps(guideline) for guideline in guidelines]))
 

--- a/gap-replay/guidelines/clean.py
+++ b/gap-replay/guidelines/clean.py
@@ -918,14 +918,8 @@ def combine_guidelines(dir_path, out_path, sources=None, min_chars=10):
             continue
         print(file)
         source_guidelines = read_jsonl(os.path.join(dir_path, file))
-        if 'clean_text' in source_guidelines[0].keys():
-            for g in source_guidelines:
-                g_new = g.copy()
-                g_new['text'] = g['clean_text']
-                del g_new['raw_text']
-                del g_new['clean_text']
-                if len(g['text']) > min_chars:
-                    guidelines.append(g_new)
+        source_guidelines = [g for g in source_guidelines if g[k] and len(g[k]) > min_chars]
+        guidelines.extend(source_guidelines)
     with open(out_path, 'w') as f_out:
         f_out.write('\n'.join([json.dumps(guideline) for guideline in guidelines]))
 


### PR DESCRIPTION
Meditron x [MedPrompt](https://arxiv.org/abs/2311.16452)
 
Here's a first step to run MedPrompt on Meditron. This code is untested and your reviews are very welcome. 

MedPrompt is composed of 3 steps: 
1. **Dynamic few-shot** by adding to the prompt 5 QA examples with highest cosine similarity to the query (added)
- Embed all training questions using OpenAI's 'text-embedding-ada-002' 
- Select top K exemplars (K = args.shots) with highest similarity to the question at hand for each test question
2. **CoT** (already implemented)
3. **Ensemble with Choice shuffling**: From the 5-shot CoT prompt, generate multiple answers (with CoT as well) and select majority vote. Choice shuffling avoids the bias of choosing certain options more frequently (we already had self-consistency, only added choice shuffling)
- Add choice shuffling through Benchmark.load_data() and custom_preprocessing for MCQ benchmarks to debias final test questions
- Check shuffling random seed for reproduciblity 

**NOTE**: in the original paper, potential candidates for KNN exemplars are QA pairs 'aced' by the model in 0-shot
For now, this is not implemented, because it requires to run inference on the dataset beforehand. 
However, we might be able to collect correct QA pairs from our past 0-shot evaluations runs


For reference, here is the MedPrompt algorithm: 

```
ALGORITHM
Input: Development data D, Test question Q 

A) PREPROCESSING:
for each question q in D:
    Get an embedding vector vq for q.
    Generate a chain-of-thought Cq and an answer Aq with the LLM. 
    if Answer Aq is correct then
        Store the embedding vector vq, chain-of-thought Cq, and answer Aq.
        
B) INFERENCE:
Compute the embedding vQ for the test question Q.
Select the K most similar examples {(vQi , CQi , AQi )}_{i=1}^K from the preprocessed training data using KNN,
    with the distance function as the cosine similarity: dist(vq,vQ)=1−⟨vq,vQ⟩/(||vq||*||vQ||)
Format the K examples as context C for the LLM. 
for i=1 to K:
    Shuffle the answer choices of the test question.
    Generate a chain-of-thought Cqk and an answer Akq with the LLM and context C.
Compute the majority vote of the generated answers A_Final = mode({Akq}_{k=1}^K)
```