### PR TITLE
Drugs and GC scrappers update along minor improvements

### DIFF
--- a/gap-replay/guidelines/requirements.txt
+++ b/gap-replay/guidelines/requirements.txt
@@ -10,3 +10,4 @@ webdriver-manager
 spacy
 langdetect
 pypdf2
+scipdf

--- a/gap-replay/guidelines/scrapers/scrapers.py
+++ b/gap-replay/guidelines/scrapers/scrapers.py
@@ -1,10 +1,10 @@
 '''
 Script for 12/16 Chrome (Firefox, experimentally)-based guideline scrapers.
 
-Sources supported: 
+Sources supported:
 AAFP - American Academy of Family Physicians
 CCO - Cancer Care Ontario
-CDC - Centers for Disease Control and Prevention 
+CDC - Centers for Disease Control and Prevention
 CMA - Canadian Medical Association
 CPS - Canadian Paediatric Society
 Drugs.com
@@ -271,7 +271,7 @@ class Scraper():
     def scrape(self):
         '''
         Scrape articles to self.path/{source}/{source}.jsonl.
-        1 - Download links to source articles. 
+        1 - Download links to source articles.
         2 - Download articles from links.
         3 - Convert PDFs to text (if necessary)
         '''
@@ -307,7 +307,7 @@ class AAFPScraper(Scraper):
         topics = list(set([href.get_attribute("href") for href in elements]))
         links = []
         for topic in tqdm(topics):
-            try: 
+            try:
                 self.driver.get(topic)
                 wait = WebDriverWait(self.driver, 10)
                 elements = wait.until(EC.presence_of_all_elements_located((
@@ -352,7 +352,7 @@ class CCOScraper(Scraper):
         links = [link for link in links if 'cancercareontario' in link]
         self.save_links(links)
         return links
-    
+
     def scrape_articles(self, links):
         os.makedirs(self.pdf_path, exist_ok=True)
         for link in tqdm(links):
@@ -530,7 +530,7 @@ class CMAScraper(Scraper):
 
 class CPSScraper(Scraper):
     '''
-    Source: CPS - Canadian Paediatric Society 
+    Source: CPS - Canadian Paediatric Society
     '''
     def __init__(self, path, **kwargs):
         super().__init__('cps', path, **kwargs)
@@ -829,7 +829,7 @@ class MAGICScraper(Scraper):
                     ran.set_description("Waiting for more click")
                     time.sleep(7)
                 except:
-                    pass  
+                    pass
                 wait = WebDriverWait(self.driver, 10)
                 element = wait.until(EC.presence_of_element_located((
                     By.XPATH, "//main[@class='centerPanel noTabs']/div[@id='mainContent']//div[@class='guidelinePanel']")))

--- a/gap-replay/guidelines/scrapers/scrapers.py
+++ b/gap-replay/guidelines/scrapers/scrapers.py
@@ -92,7 +92,8 @@ def setup_chrome_driver(
     include_experimental: bool = True,
     download_path: str = None,
     binary_location: str = None,
-    driver_location: str = None
+    driver_location: str = None,
+    headless: bool = False
 ):
     '''
     Set up Chrome driver instance with download path.
@@ -102,7 +103,9 @@ def setup_chrome_driver(
     if binary_location:
         chrome_options.binary_location = binary_location
 
-    chrome_options.add_argument('--headless')
+    if headless:
+        chrome_options.add_argument('--headless')
+
     chrome_options.add_argument('--no-sandbox')
     chrome_options.add_argument('--disable-dev-shm-usage')
     chrome_options.add_argument("--disable-extensions")

--- a/gap-replay/guidelines/scrapers/scrapers.py
+++ b/gap-replay/guidelines/scrapers/scrapers.py
@@ -93,7 +93,8 @@ def setup_chrome_driver(
     download_path: str = None,
     binary_location: str = None,
     driver_location: str = None,
-    headless: bool = False
+    headless: bool = False,
+    eager_mode: bool = False
 ):
     '''
     Set up Chrome driver instance with download path.
@@ -103,6 +104,9 @@ def setup_chrome_driver(
     if binary_location:
         chrome_options.binary_location = binary_location
 
+    if eager_mode:
+        chrome_options.page_load_strategy = 'eager'
+
     if headless:
         chrome_options.add_argument('--headless')
 
@@ -111,7 +115,6 @@ def setup_chrome_driver(
     chrome_options.add_argument("--disable-extensions")
     chrome_options.add_argument("--dns-prefetch-disable")
     chrome_options.add_argument("--disable-gpu")
-    chrome_options.page_load_strategy = 'eager'
 
     if include_experimental:
         assert download_path is not None, "Download path must be provided if including experimental options."


### PR DESCRIPTION
- Updated `DrugsScrapper` and `GCScrapper` to avoid issues.
- Optimization of `Scrapper` to use the cached links already fetched by previous runs to skip the link gathering.
- Optimization of the chrome driver and handling of more options, of which some are necessary on windows (binary and driver locations) and others optional (headless, page loading mode, and pdf download folder).
- One missing requirement: *scipdf*.