### PR TITLE
Fix issue #38 Can't benchmark on medqa

### DIFF
--- a/evaluation/benchmarks.py
+++ b/evaluation/benchmarks.py
@@ -425,6 +425,7 @@ class MedQA(Benchmark):
         self.path = os.path.join(ROOT_DIR, 'benchmarks', 'datasets', self.dir_name)
         self.splits = ['train', 'validation', 'test']
         self.num_options = 5
+        self.subsets = ['med_qa_en_source']
 
     @staticmethod
     def custom_preprocessing(row):

--- a/evaluation/evaluate.py
+++ b/evaluation/evaluate.py
@@ -239,7 +239,7 @@ def accuracy_metric(data, **kwargs):
 
     return {
         "accuracy": accuracy_score(preds, golds),
-        "accuracy_calibrate": acc / counter,
+        "accuracy_calibrate": acc / counter if counter > 0 else 0,
         "precision": precision,
         "recall": recall,
         "f1": f1,

--- a/evaluation/inference.py
+++ b/evaluation/inference.py
@@ -5,7 +5,6 @@ import numpy as np
 import pandas as pd
 import vllm
 import torch
-import openai
 
 from tqdm import tqdm
 from torch.utils.data import DataLoader

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ nltk
 tqdm
 sentencepiece # 0.1.97
 datasets # 2.14.6
+wandb
+scikit-learn


### PR DESCRIPTION
PR to fix #38 , solution provided by @JulienVig

- add `self.subsets = ['med_qa_en_source']` in `MedQA` class in `evaluation/benchmarks.py` to fix the error `datasets.exceptions.DatasetGenerationError: An error occurred while generating the dataset` when evaluation on `medqa`
- add `wandb`, `scikit-learn` packages in `requirements.txt` and remove unused import statement `import openai` in `evaluation/inference.py` 